### PR TITLE
Fix using universal apk when abi-splits are present

### DIFF
--- a/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/gradle/task/GenerateMarathonfileTask.kt
+++ b/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/gradle/task/GenerateMarathonfileTask.kt
@@ -83,8 +83,8 @@ open class GenerateMarathonfileTask @Inject constructor(objects: ObjectFactory) 
         return bundles.map {
             when(it) {
                 is GradleAndroidTestBundle.ApplicationWithTest -> {
-                        val artifactLoader = it.artifactLoader.get()
-                        val artifacts: BuiltArtifacts =
+                    val artifactLoader = it.artifactLoader.get()
+                    val artifacts: BuiltArtifacts =
                             artifactLoader.load(it.apkFolder.get()) ?: throw RuntimeException("No application artifact found")
                     val application = when {
                         artifacts.elements.size > 1 -> artifacts.elements.firstOrNull { artifact ->

--- a/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/gradle/task/GenerateMarathonfileTask.kt
+++ b/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/gradle/task/GenerateMarathonfileTask.kt
@@ -2,11 +2,6 @@ package com.malinskiy.marathon.gradle.task
 
 import com.android.build.api.variant.BuiltArtifacts
 import com.android.build.api.variant.VariantOutputConfiguration
-import com.android.build.api.variant.impl.BuiltArtifactImpl
-import com.android.build.api.variant.impl.BuiltArtifactsImpl
-import com.android.build.api.variant.impl.VariantOutputConfigurationImpl
-import com.android.build.gradle.api.ApkVariantOutput
-import com.android.builder.model.AndroidArtifactOutput
 import com.malinskiy.marathon.config.serialization.ConfigurationFactory
 import com.malinskiy.marathon.config.vendor.android.AndroidTestBundleConfiguration
 import com.malinskiy.marathon.gradle.GradleAndroidTestBundle


### PR DESCRIPTION
**Before:** plugin failed to use universalApk if abi-splits were also present.
**Now:** if abi-splits are present then look for universalApk before throwing error.

Fixes issue https://github.com/MarathonLabs/marathon-gradle-plugin/issues/2