### PR TITLE
Avoid SDK directory fingerprinting, track only path

### DIFF
--- a/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/gradle/MarathonPlugin.kt
+++ b/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/gradle/MarathonPlugin.kt
@@ -249,6 +249,7 @@ class MarathonPlugin : Plugin<Project> {
                     this.vendorConfigurationBuilder.set(vendorConfigurationJson)
                     this.jsonService.set(jsonServiceProvider)
                     sdk.set(sdkDirectory)
+                    sdkPath.set(sdkDirectory.map { dir -> dir.asFile.name })
                     marathonfile.set(project.layout.buildDirectory.dir("marathon").map { it.dir(variantName) }
                                          .map { it.file("Marathonfile") })
                 }

--- a/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/gradle/task/GenerateMarathonfileTask.kt
+++ b/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/gradle/task/GenerateMarathonfileTask.kt
@@ -14,12 +14,9 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.OutputFile
-import org.gradle.api.tasks.PathSensitive
-import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.kotlin.dsl.listProperty
 import org.gradle.kotlin.dsl.property
@@ -44,20 +41,22 @@ open class GenerateMarathonfileTask @Inject constructor(objects: ObjectFactory) 
     @Nested
     val applicationBundle: ListProperty<GradleAndroidTestBundle> = objects.listProperty()
 
-    @InputDirectory
-    @PathSensitive(PathSensitivity.NAME_ONLY)
+    @Internal
     val sdk: DirectoryProperty = objects.directoryProperty()
+
+    @Input
+    val sdkPath: Property<String> = objects.property()
 
     @OutputFile
     val marathonfile: RegularFileProperty = objects.fileProperty()
 
     @Internal
     val jsonService: Property<JsonService> = objects.property()
-    
+
     @TaskAction
     fun write() {
         val json = jsonService.get()
-        
+
         // Override stuff coming from AGP
         val androidConfiguration = vendorConfigurationBuilder.let { json.parseVendor(it.get()) }.apply {
             androidSdk = sdk.get().asFile


### PR DESCRIPTION
We’ve observed long execution times for `GenerateMarathonfileTask` in certain scenarios. For example, on GitHub Actions’ free runners we see the following Build Scan: https://ge.solutions-team.gradle.com/s/4pgldcb757x2a/timeline?details=4ny4mggvxihlu. 
The time is dominated by input fingerprinting—22m 42.198s in that build. Fingerprinting is the hashing that Gradle performs over a task’s inputs. In Marathon’s case, the main contributor is the `sdk` property: on environments like GHA that provide multiple Android SDK versions, the file count becomes very large, which makes fingerprinting extremely slow.

This PR marks `sdk` as `@Internal` to avoid tracking its contents and adds an optional `sdkPath`: String input so we can still track the path if needed. Let me know if `sdkPath` is required; otherwise I can remove it.